### PR TITLE
refactor: use command name for registry

### DIFF
--- a/src/rest/cache.ts
+++ b/src/rest/cache.ts
@@ -1,9 +1,9 @@
 import { Collection, EventHandlers } from "../../deps.ts";
-import Command from "./common/command/Command.ts";
+import CommandCollection from "./common/command/CommandCollection.ts";
 import type { GuildSettings } from "./common/service/internal-api/guild_settings.ts";
 
 export const bot = {
-  commands: new Collection<string, Command>(),
+  commands: new CommandCollection(),
   events: {} as EventHandlers,
   guildSettings: new Collection<bigint, GuildSettings>(),
 };

--- a/src/rest/commands/animal/animal.ts
+++ b/src/rest/commands/animal/animal.ts
@@ -215,4 +215,4 @@ AnimalCommand.options = {
   ],
 };
 
-bot.commands.set("animal", AnimalCommand);
+bot.commands.set(AnimalCommand.options.name, AnimalCommand);

--- a/src/rest/commands/animal/animal.ts
+++ b/src/rest/commands/animal/animal.ts
@@ -215,4 +215,4 @@ AnimalCommand.options = {
   ],
 };
 
-bot.commands.set(AnimalCommand.options.name, AnimalCommand);
+bot.commands.add(AnimalCommand);

--- a/src/rest/commands/animal/animalfact.ts
+++ b/src/rest/commands/animal/animalfact.ts
@@ -215,4 +215,4 @@ AnimalFactCommand.options = {
   ],
 };
 
-bot.commands.set(AnimalFactCommand.options.name, AnimalFactCommand);
+bot.commands.add(AnimalFactCommand);

--- a/src/rest/commands/animal/animalfact.ts
+++ b/src/rest/commands/animal/animalfact.ts
@@ -215,4 +215,4 @@ AnimalFactCommand.options = {
   ],
 };
 
-bot.commands.set("animalfact", AnimalFactCommand);
+bot.commands.set(AnimalFactCommand.options.name, AnimalFactCommand);

--- a/src/rest/commands/fun/advice.ts
+++ b/src/rest/commands/fun/advice.ts
@@ -27,4 +27,4 @@ AdviceCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("advice", AdviceCommand);
+bot.commands.set(AdviceCommand.options.name, AdviceCommand);

--- a/src/rest/commands/fun/advice.ts
+++ b/src/rest/commands/fun/advice.ts
@@ -27,4 +27,4 @@ AdviceCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(AdviceCommand.options.name, AdviceCommand);
+bot.commands.add(AdviceCommand);

--- a/src/rest/commands/fun/chucknorris.ts
+++ b/src/rest/commands/fun/chucknorris.ts
@@ -27,4 +27,4 @@ ChuckNorrisCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(ChuckNorrisCommand.options.name, ChuckNorrisCommand);
+bot.commands.add(ChuckNorrisCommand);

--- a/src/rest/commands/fun/chucknorris.ts
+++ b/src/rest/commands/fun/chucknorris.ts
@@ -27,4 +27,4 @@ ChuckNorrisCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("chucknorris", ChuckNorrisCommand);
+bot.commands.set(ChuckNorrisCommand.options.name, ChuckNorrisCommand);

--- a/src/rest/commands/fun/coinflip.ts
+++ b/src/rest/commands/fun/coinflip.ts
@@ -18,4 +18,4 @@ CoinflipCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("coinflip", CoinflipCommand);
+bot.commands.set(CoinflipCommand.options.name, CoinflipCommand);

--- a/src/rest/commands/fun/coinflip.ts
+++ b/src/rest/commands/fun/coinflip.ts
@@ -18,4 +18,4 @@ CoinflipCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(CoinflipCommand.options.name, CoinflipCommand);
+bot.commands.add(CoinflipCommand);

--- a/src/rest/commands/fun/dice.ts
+++ b/src/rest/commands/fun/dice.ts
@@ -79,4 +79,4 @@ DiceCommand.options = {
   ],
 };
 
-bot.commands.set(DiceCommand.options.name, DiceCommand);
+bot.commands.add(DiceCommand);

--- a/src/rest/commands/fun/dice.ts
+++ b/src/rest/commands/fun/dice.ts
@@ -79,4 +79,4 @@ DiceCommand.options = {
   ],
 };
 
-bot.commands.set("dice", DiceCommand);
+bot.commands.set(DiceCommand.options.name, DiceCommand);

--- a/src/rest/commands/fun/meme.ts
+++ b/src/rest/commands/fun/meme.ts
@@ -34,4 +34,4 @@ MemeCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("meme", MemeCommand);
+bot.commands.set(MemeCommand.options.name, MemeCommand);

--- a/src/rest/commands/fun/meme.ts
+++ b/src/rest/commands/fun/meme.ts
@@ -34,4 +34,4 @@ MemeCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(MemeCommand.options.name, MemeCommand);
+bot.commands.add(MemeCommand);

--- a/src/rest/commands/fun/pun.ts
+++ b/src/rest/commands/fun/pun.ts
@@ -25,4 +25,4 @@ PunCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(PunCommand.options.name, PunCommand);
+bot.commands.add(PunCommand);

--- a/src/rest/commands/fun/pun.ts
+++ b/src/rest/commands/fun/pun.ts
@@ -25,4 +25,4 @@ PunCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("pun", PunCommand);
+bot.commands.set(PunCommand.options.name, PunCommand);

--- a/src/rest/commands/fun/thouart.ts
+++ b/src/rest/commands/fun/thouart.ts
@@ -25,4 +25,4 @@ ThouartCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(ThouartCommand.options.name, ThouartCommand);
+bot.commands.add(ThouartCommand);

--- a/src/rest/commands/fun/thouart.ts
+++ b/src/rest/commands/fun/thouart.ts
@@ -25,4 +25,4 @@ ThouartCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("thouart", ThouartCommand);
+bot.commands.set(ThouartCommand.options.name, ThouartCommand);

--- a/src/rest/commands/fun/yearfact.ts
+++ b/src/rest/commands/fun/yearfact.ts
@@ -23,4 +23,4 @@ YearFactCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(YearFactCommand.options.name, YearFactCommand);
+bot.commands.add(YearFactCommand);

--- a/src/rest/commands/fun/yearfact.ts
+++ b/src/rest/commands/fun/yearfact.ts
@@ -23,4 +23,4 @@ YearFactCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("yearfact", YearFactCommand);
+bot.commands.set(YearFactCommand.options.name, YearFactCommand);

--- a/src/rest/commands/fun/yomama.ts
+++ b/src/rest/commands/fun/yomama.ts
@@ -23,4 +23,4 @@ YomamaCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(YomamaCommand.options.name, YomamaCommand);
+bot.commands.add(YomamaCommand);

--- a/src/rest/commands/fun/yomama.ts
+++ b/src/rest/commands/fun/yomama.ts
@@ -23,4 +23,4 @@ YomamaCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("yomama", YomamaCommand);
+bot.commands.set(YomamaCommand.options.name, YomamaCommand);

--- a/src/rest/commands/general/docs.ts
+++ b/src/rest/commands/general/docs.ts
@@ -16,4 +16,4 @@ DocsCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("docs", DocsCommand);
+bot.commands.set(DocsCommand.options.name, DocsCommand);

--- a/src/rest/commands/general/docs.ts
+++ b/src/rest/commands/general/docs.ts
@@ -16,4 +16,4 @@ DocsCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(DocsCommand.options.name, DocsCommand);
+bot.commands.add(DocsCommand);

--- a/src/rest/commands/general/invite.ts
+++ b/src/rest/commands/general/invite.ts
@@ -16,4 +16,4 @@ InviteCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("invite", InviteCommand);
+bot.commands.set(InviteCommand.options.name, InviteCommand);

--- a/src/rest/commands/general/invite.ts
+++ b/src/rest/commands/general/invite.ts
@@ -16,4 +16,4 @@ InviteCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(InviteCommand.options.name, InviteCommand);
+bot.commands.add(InviteCommand);

--- a/src/rest/commands/general/premium.ts
+++ b/src/rest/commands/general/premium.ts
@@ -16,4 +16,4 @@ PremiumCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set(PremiumCommand.options.name, PremiumCommand);
+bot.commands.add(PremiumCommand);

--- a/src/rest/commands/general/premium.ts
+++ b/src/rest/commands/general/premium.ts
@@ -16,4 +16,4 @@ PremiumCommand.options = {
   description: "No description available.",
 };
 
-bot.commands.set("premium", PremiumCommand);
+bot.commands.set(PremiumCommand.options.name, PremiumCommand);

--- a/src/rest/commands/information/ping.ts
+++ b/src/rest/commands/information/ping.ts
@@ -16,4 +16,4 @@ PingCommand.options = {
   description: "Check to see if TypicalBot is online and responsive.",
 };
 
-bot.commands.set(PingCommand.options.name, PingCommand);
+bot.commands.add(PingCommand);

--- a/src/rest/commands/information/ping.ts
+++ b/src/rest/commands/information/ping.ts
@@ -16,4 +16,4 @@ PingCommand.options = {
   description: "Check to see if TypicalBot is online and responsive.",
 };
 
-bot.commands.set("ping", PingCommand);
+bot.commands.set(PingCommand.options.name, PingCommand);

--- a/src/rest/commands/moderation/ban.ts
+++ b/src/rest/commands/moderation/ban.ts
@@ -112,4 +112,4 @@ BanCommand.options = {
   ],
 };
 
-bot.commands.set("ban", BanCommand);
+bot.commands.set(BanCommand.options.name, BanCommand);

--- a/src/rest/commands/moderation/ban.ts
+++ b/src/rest/commands/moderation/ban.ts
@@ -112,4 +112,4 @@ BanCommand.options = {
   ],
 };
 
-bot.commands.set(BanCommand.options.name, BanCommand);
+bot.commands.add(BanCommand);

--- a/src/rest/commands/moderation/kick.ts
+++ b/src/rest/commands/moderation/kick.ts
@@ -109,4 +109,4 @@ KickCommand.options = {
   ],
 };
 
-bot.commands.set("kick", KickCommand);
+bot.commands.set(KickCommand.options.name, KickCommand);

--- a/src/rest/commands/moderation/kick.ts
+++ b/src/rest/commands/moderation/kick.ts
@@ -109,4 +109,4 @@ KickCommand.options = {
   ],
 };
 
-bot.commands.set(KickCommand.options.name, KickCommand);
+bot.commands.add(KickCommand);

--- a/src/rest/commands/moderation/purge.ts
+++ b/src/rest/commands/moderation/purge.ts
@@ -110,4 +110,4 @@ PurgeCommand.options = {
   ],
 };
 
-bot.commands.set(PurgeCommand.options.name, PurgeCommand);
+bot.commands.add(PurgeCommand);

--- a/src/rest/commands/moderation/purge.ts
+++ b/src/rest/commands/moderation/purge.ts
@@ -110,4 +110,4 @@ PurgeCommand.options = {
   ],
 };
 
-bot.commands.set("purge", PurgeCommand);
+bot.commands.set(PurgeCommand.options.name, PurgeCommand);

--- a/src/rest/commands/moderation/say.ts
+++ b/src/rest/commands/moderation/say.ts
@@ -37,4 +37,4 @@ SayCommand.options = {
   ],
 };
 
-bot.commands.set(SayCommand.options.name, SayCommand);
+bot.commands.add(SayCommand);

--- a/src/rest/commands/moderation/say.ts
+++ b/src/rest/commands/moderation/say.ts
@@ -37,4 +37,4 @@ SayCommand.options = {
   ],
 };
 
-bot.commands.set("say", SayCommand);
+bot.commands.set(SayCommand.options.name, SayCommand);

--- a/src/rest/commands/system/debug.ts
+++ b/src/rest/commands/system/debug.ts
@@ -100,4 +100,4 @@ DebugCommand.options = {
   ],
 };
 
-bot.commands.set(DebugCommand.options.name, DebugCommand);
+bot.commands.add(DebugCommand);

--- a/src/rest/commands/system/debug.ts
+++ b/src/rest/commands/system/debug.ts
@@ -100,4 +100,4 @@ DebugCommand.options = {
   ],
 };
 
-bot.commands.set("debug", DebugCommand);
+bot.commands.set(DebugCommand.options.name, DebugCommand);

--- a/src/rest/common/command/CommandCollection.ts
+++ b/src/rest/common/command/CommandCollection.ts
@@ -1,0 +1,10 @@
+import { Collection } from "../../../../deps.ts";
+import Command from "./Command.ts";
+
+class CommandCollection extends Collection<string, Command> {
+  add(command: Command) {
+    super.set(command.options.name, command);
+  }
+}
+
+export default CommandCollection;


### PR DESCRIPTION
Instead of typing out the command name more than once, we can use the name provided in the options array for the registry. 