### PR TITLE
refactor: use application owner for debug command

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/discordeno@11.2.0/mod.ts";
+export * from "https://deno.land/x/discordeno@12.0.0-rc.3/mod.ts";

--- a/src/rest/cache.ts
+++ b/src/rest/cache.ts
@@ -6,4 +6,5 @@ export const bot = {
   commands: new CommandCollection(),
   events: {} as EventHandlers,
   guildSettings: new Collection<bigint, GuildSettings>(),
+  applicationOwners: [] as string[]
 };

--- a/src/rest/cache.ts
+++ b/src/rest/cache.ts
@@ -6,5 +6,5 @@ export const bot = {
   commands: new CommandCollection(),
   events: {} as EventHandlers,
   guildSettings: new Collection<bigint, GuildSettings>(),
-  applicationOwners: [] as string[]
+  applicationOwners: [] as string[],
 };

--- a/src/rest/commands/system/debug.ts
+++ b/src/rest/commands/system/debug.ts
@@ -10,7 +10,7 @@ import { enTranslate } from "../../common/util/i18next.ts";
 
 const DebugCommand: Command = (interaction) => {
   // TODO: Change to use application team owners
-  if (interaction.member!.user!.id !== "187342661060001792") {
+  if (!bot.applicationOwners.includes(interaction.member!.user!.id)) {
     return basicInteractionResponse(
       interaction.id,
       interaction.token,

--- a/src/rest/mod.ts
+++ b/src/rest/mod.ts
@@ -5,7 +5,9 @@ import {
   EVENT_HANDLER_SECRET_KEY,
 } from "../config.ts";
 import {
+  Application,
   camelize,
+  endpoints,
   GatewayPayload,
   handlers,
   rest,
@@ -37,6 +39,22 @@ rest.token = `Bot ${DISCORD_TOKEN}`;
 // Manually set botId and applicationId as ready event not emitted
 setBotId(DISCORD_ID!);
 setApplicationId(DISCORD_ID!);
+// TODO: Remove this once Discordeno has a helper function for this
+// Manually add application owners
+const rawApplicationData = await rest.runMethod<Omit<Application, "flags">>(
+  "get",
+  endpoints.OAUTH2_APPLICATION,
+);
+
+if (rawApplicationData) {
+  if (rawApplicationData.team) {
+    rawApplicationData.team.members.forEach((m) =>
+      bot.applicationOwners.push(m.user.id)
+    );
+  } else {
+    bot.applicationOwners.push(rawApplicationData.owner!.id!);
+  }
+}
 // Manually upsert slash commands as ready event not emitted
 const globalCommands = [];
 

--- a/src/rest/mod.ts
+++ b/src/rest/mod.ts
@@ -5,10 +5,9 @@ import {
   EVENT_HANDLER_SECRET_KEY,
 } from "../config.ts";
 import {
-  Application,
   camelize,
-  endpoints,
   GatewayPayload,
+  getApplicationInfo,
   handlers,
   rest,
   setApplicationId,
@@ -41,18 +40,15 @@ setBotId(DISCORD_ID!);
 setApplicationId(DISCORD_ID!);
 // TODO: Remove this once Discordeno has a helper function for this
 // Manually add application owners
-const rawApplicationData = await rest.runMethod<Omit<Application, "flags">>(
-  "get",
-  endpoints.OAUTH2_APPLICATION,
-);
+const applicationInfo = await getApplicationInfo();
 
-if (rawApplicationData) {
-  if (rawApplicationData.team) {
-    rawApplicationData.team.members.forEach((m) =>
+if (applicationInfo) {
+  if (applicationInfo.team) {
+    applicationInfo.team.members.forEach((m) =>
       bot.applicationOwners.push(m.user.id)
     );
   } else {
-    bot.applicationOwners.push(rawApplicationData.owner!.id!);
+    bot.applicationOwners.push(applicationInfo.owner!.id!);
   }
 }
 // Manually upsert slash commands as ready event not emitted


### PR DESCRIPTION
Use application owners for debug command instead of only using my ID. Waiting to see if Discordeno can add function for retrieving application info, otherwise will create our own method. 